### PR TITLE
Switch Validate() interface to only return "error", simplifying code that uses it

### DIFF
--- a/control/dsc.go
+++ b/control/dsc.go
@@ -22,7 +22,6 @@ package control
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -173,35 +172,25 @@ func (d *DSC) Maintainers() []string {
 	return append([]string{d.Maintainer}, d.Uploaders...)
 }
 
-func (d DSC) validateHash(hash DebianFileHash) (bool, error) {
-	hash.Filename = filepath.Join(filepath.Dir(d.Filename), hash.Filename)
-	if ok, err := hash.Validate(); err != nil {
-		return false, fmt.Errorf("Error: validating %s failed: %v", hash.Filename, err)
-	} else if !ok {
-		return false, fmt.Errorf("Error: %s is invalid", hash.Filename)
-	}
-	return true, nil
-}
-
 // Validate the attached files by checking the target Filesize and Checksum.
-func (d DSC) Validate() (bool, error) {
+func (d DSC) Validate() error {
 	for _, f := range d.ChecksumsSha1 {
-		if ok, err := d.validateHash(f.DebianFileHash); err != nil || !ok {
-			return ok, err
+		if err := f.Validate(); err != nil {
+			return err
 		}
 	}
 	for _, f := range d.ChecksumsSha256 {
-		if ok, err := d.validateHash(f.DebianFileHash); err != nil || !ok {
-			return ok, err
+		if err := f.Validate(); err != nil {
+			return err
 		}
 	}
 	for _, f := range d.Files {
-		if ok, err := d.validateHash(f.DebianFileHash); err != nil || !ok {
-			return ok, err
+		if err := f.Validate(); err != nil {
+			return err
 		}
 	}
 	// TODO also verify that all three lists contain the _same_ files (and the same filesizes)
-	return true, nil
+	return nil
 }
 
 // vim: foldmethod=marker

--- a/control/filehash.go
+++ b/control/filehash.go
@@ -59,12 +59,12 @@ type DebianFileHash struct {
 }
 
 // Validate the DebianFileHash by checking the target Filesize and Checksum.
-func (d *DebianFileHash) Validate() (bool, error) {
+func (d DebianFileHash) Validate() error {
 	var algo hash.Hash
 
 	stat, err := os.Stat(d.Filename)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if size := stat.Size(); size != int64(d.Size) {
 		return false, fmt.Errorf("Error! Size mismatch! %d != %d", size, d.Size)
@@ -78,13 +78,16 @@ func (d *DebianFileHash) Validate() (bool, error) {
 	case "sha256":
 		algo = sha256.New()
 	default:
-		return false, fmt.Errorf("Unknown algorithm: %s", d.Algorithm)
+		return fmt.Errorf("Unknown algorithm: %s", d.Algorithm)
 	}
 	fileHash, err := hashFile(d.Filename, algo)
 	if err != nil {
-		return false, err
+		return fmt.Errorf("Hash failed: %v", err)
 	}
-	return fileHash == d.Hash, nil
+	if fileHash != d.Hash {
+		return fmt.Errorf("Incorrect hash: %q != %q", fileHash, d.Hash)
+	}
+	return nil
 }
 
 // {{{ SHA DebianFileHash (both 1 and 256)


### PR DESCRIPTION
@paultag hopefully this interface is as much cleaner in your eyes as it is in mine -- I think if `bool` is really a necessary interface, then adding an `IsValid()` wrapper is probably the best bet :smile: