### PR TITLE
Add version.Slice which fulfills sort.Interface

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -37,6 +37,21 @@ import (
 	"unicode"
 )
 
+// Slice is a slice versions, satisfying sort.Interface
+type Slice []Version
+
+func (a Slice) Len() int {
+	return len(a)
+}
+
+func (a Slice) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a Slice) Less(i, j int) bool {
+	return Compare(a[i], a[j]) < 0
+}
+
 type Version struct {
 	Epoch    uint
 	Version  string


### PR DESCRIPTION
That way, you can write code like this:

```go
package main

import (
    "log"
    "sort"

    "pault.ag/go/debian/version"
)

func main() {
    first, err := version.Parse("0.1")
    if err != nil {
        log.Fatal(err)
    }

    second, err := version.Parse("0.2")
    if err != nil {
        log.Fatal(err)
    }

    a := []version.Version{
        first,
        second,
    }

    log.Println(a)
    sort.Sort(version.Slice(a))
    log.Println(a)
    sort.Sort(sort.Reverse(version.Slice(a)))
    log.Println(a)
}
```