### PR TITLE
Add a "SatisfiedBy" function to "VersionRelation" objects

### DIFF
--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -20,6 +20,10 @@
 
 package dependency
 
+import (
+	"pault.ag/go/debian/version"
+)
+
 //
 func (dep *Dependency) GetPossibilities(arch Arch) []Possibility {
 	possies := []Possibility{}
@@ -69,6 +73,30 @@ func (dep *Dependency) GetSubstvars() []Possibility {
 	}
 
 	return possies
+}
+
+func (v VersionRelation) SatisfiedBy(ver version.Version) bool {
+	vVer, err := version.Parse(v.Number)
+	if err != nil {
+		return false
+	}
+
+	q := version.Compare(ver, vVer)
+	switch v.Operator {
+	case ">=":
+		return q >= 0
+	case "<=":
+		return q <= 0
+	case ">>":
+		return q > 0
+	case "<<":
+		return q < 0
+	case "=":
+		return q == 0
+	}
+
+	// XXX: WHAT THE SHIT
+	return false
 }
 
 // vim: foldmethod=marker

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"pault.ag/go/debian/dependency"
+	"pault.ag/go/debian/version"
 )
 
 /*
@@ -84,6 +85,37 @@ func TestSliceSubParse(t *testing.T) {
 
 	assert(t, els[0].Name == "foo:Depends")
 	assert(t, els[1].Name == "bar:Depends")
+}
+
+func TestVersionRelationSatisfiedBy(t *testing.T) {
+	for _, test := range []struct {
+		Operator string
+		Number   string
+		Version  string
+		Match    bool
+	}{
+		{"=", "1.0.0", "1.0.0", true},
+		{"=", "1.0.1", "1.0.0", false},
+		{"=", "1.0.0", "1.0.1", false},
+		{"<<", "2.0", "1.0", true},
+		{">>", "2.0", "1.0", false},
+		{">>", "2.0", "3.0", true},
+		{"<<", "2.0", "3.0", false},
+		{">=", "1.0~", "1.0", true},
+		{">=", "1.0~", "1.0.2", true},
+		{">=", "1.0~", "1.0.2.3", true},
+		{"<=", "1.0~", "1.0", false},
+		{"<=", "1.0~", "1.0.2", false},
+		{"<=", "1.0~", "1.0.2.3", false},
+	} {
+		vr := dependency.VersionRelation{
+			Operator: test.Operator,
+			Number:   test.Number,
+		}
+		v, err := version.Parse(test.Version)
+		assert(t, err == nil)
+		assert(t, vr.SatisfiedBy(v) == test.Match)
+	}
 }
 
 // vim: foldmethod=marker


### PR DESCRIPTION
This makes comparisons a snap!

Code "stolen" from [`Candidates.ExplainSatisfies`](https://github.com/paultag/go-resolver/blob/ebf7e68577f7d86bf91628ac4b1cba5a89cba623/index.go#L106-L122).