### PR TITLE
Fix handling of negated ArchSets to match Policy

### DIFF
--- a/dependency/parser.go
+++ b/dependency/parser.go
@@ -349,14 +349,6 @@ func parsePossibilityArchs(input *Input, possi *Possibility) error {
 	eatWhitespace(input)
 	input.Next() /* Assert ch == '[' */
 
-	/* So the first line of each guy can be a not (!), so let's check for
-	 * that with a Peek :) */
-	peek := input.Peek()
-	if peek == '!' {
-		input.Next() /* Omnom */
-		possi.Architectures.Not = true
-	}
-
 	for {
 		peek := input.Peek()
 		switch peek {
@@ -378,6 +370,19 @@ func parsePossibilityArchs(input *Input, possi *Possibility) error {
 func parsePossibilityArch(input *Input, possi *Possibility) error {
 	eatWhitespace(input)
 	arch := ""
+
+	// Exclamation marks may be prepended to each of the names. (It is not
+	// permitted for some names to be prepended with exclamation marks while
+	// others aren't.)
+	hasNot := input.Peek() == '!'
+	if hasNot {
+		input.Next() // '!'
+	}
+	if len(possi.Architectures.Architectures) == 0 {
+		possi.Architectures.Not = hasNot
+	} else if possi.Architectures.Not != hasNot {
+		return errors.New("Either the entire arch list needs negations, or none of it does -- no mix and match :/")
+	}
 
 	for {
 		peek := input.Peek()

--- a/dependency/string.go
+++ b/dependency/string.go
@@ -43,15 +43,15 @@ func (set ArchSet) String() string {
 	if len(set.Architectures) == 0 {
 		return ""
 	}
-	arches := []string{}
-	for _, arch := range set.Architectures {
-		arches = append(arches, arch.String())
-	}
 	not := ""
 	if set.Not {
 		not = "!"
 	}
-	return "[" + not + strings.Join(arches, " ") + "]"
+	arches := []string{}
+	for _, arch := range set.Architectures {
+		arches = append(arches, not + arch.String())
+	}
+	return "[" + strings.Join(arches, " ") + "]"
 }
 
 func (version VersionRelation) String() string {


### PR DESCRIPTION
See 7.1 (https://www.debian.org/doc/debian-policy/ch-relationships.html), especially:

> Relationships may be restricted to a certain set of architectures. This is indicated in brackets after each individual package name and the optional version specification. The brackets enclose a non-empty list of Debian architecture names in the format described in Architecture specification strings, Section 11.1, separated by whitespace. **Exclamation marks may be prepended to each of the names. (It is not permitted for some names to be prepended with exclamation marks while others aren't.)**

(Emphasis mine.)

This fixes the parser and stringification, and updates relevant tests to better verify that this is functioning properly.