### PR TITLE
Return io.EOF when encountering it

### DIFF
--- a/changelog/changelog_test.go
+++ b/changelog/changelog_test.go
@@ -22,6 +22,7 @@ package changelog_test
 
 import (
 	"bufio"
+	"io"
 	"log"
 	"strings"
 	"testing"
@@ -34,7 +35,7 @@ import (
  */
 
 func isok(t *testing.T, err error) {
-	if err != nil {
+	if err != nil && err != io.EOF {
 		log.Printf("Error! Error is not nil! %s\n", err)
 		t.FailNow()
 	}

--- a/control/changes.go
+++ b/control/changes.go
@@ -110,11 +110,7 @@ func ParseChangesFile(path string) (ret *Changes, err error) {
 	}
 	defer f.Close()
 
-	ret, err = ParseChanges(bufio.NewReader(f), path)
-	if err != nil {
-		return nil, err
-	}
-	return ret, nil
+	return ParseChanges(bufio.NewReader(f), path)
 }
 
 // Given a bufio.Reader, consume the Reader, and return a Changes object
@@ -124,10 +120,7 @@ func ParseChangesFile(path string) (ret *Changes, err error) {
 // to something invalid if you're not using those functions.
 func ParseChanges(reader *bufio.Reader, path string) (*Changes, error) {
 	ret := &Changes{Filename: path}
-	if err := Unmarshal(ret, reader); err != nil {
-		return nil, err
-	}
-	return ret, nil
+	return ret, Unmarshal(ret, reader)
 }
 
 // Return a DSC struct for the DSC listed in the .changes file. This requires
@@ -176,12 +169,7 @@ func (changes *Changes) Copy(dest string) error {
 	dirname := filepath.Base(changes.Filename)
 	err := internal.Copy(changes.Filename, dest+"/"+dirname)
 	changes.Filename = dest + "/" + dirname
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // Move the .changes file and all refrenced files to the directory
@@ -207,12 +195,7 @@ func (changes *Changes) Move(dest string) error {
 	dirname := filepath.Base(changes.Filename)
 	err := os.Rename(changes.Filename, dest+"/"+dirname)
 	changes.Filename = dest + "/" + dirname
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // Remove the .changes file and any associated files. This function will
@@ -225,11 +208,7 @@ func (changes *Changes) Remove() error {
 			return err
 		}
 	}
-	err := os.Remove(changes.Filename)
-	if err != nil {
-		return err
-	}
-	return nil
+	return os.Remove(changes.Filename)
 }
 
 // vim: foldmethod=marker

--- a/control/decode.go
+++ b/control/decode.go
@@ -239,7 +239,7 @@ func isParagraph(incoming reflect.Value) (int, bool) {
 func unmarshalStruct(incoming interface{}, data io.Reader) error {
 	reader := bufio.NewReader(data)
 	para, err := ParseParagraph(reader)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return err
 	}
 	if para == nil {

--- a/control/parse.go
+++ b/control/parse.go
@@ -103,9 +103,9 @@ func ParseParagraph(reader *bufio.Reader) (*Paragraph, error) {
 		line, err := reader.ReadString('\n')
 		if err == io.EOF {
 			if len(ret.Order) == 0 {
-				return nil, nil
+				return nil, err
 			}
-			return ret, nil
+			return ret, err
 		}
 		if line == "\n" {
 			break

--- a/control/parse_test.go
+++ b/control/parse_test.go
@@ -22,6 +22,7 @@ package control_test
 
 import (
 	"bufio"
+	"io"
 	"log"
 	"strings"
 	"testing"
@@ -34,7 +35,7 @@ import (
  */
 
 func isok(t *testing.T, err error) {
-	if err != nil {
+	if err != nil && err != io.EOF {
 		log.Printf("Error! Error is not nil! - %s\n", err)
 		t.FailNow()
 	}
@@ -72,7 +73,7 @@ func TestBasicControlParse(t *testing.T) {
 	reader = bufio.NewReader(strings.NewReader(`Foo: bar`))
 	deb822, err = control.ParseParagraph(reader)
 	assert(t, deb822 == nil)
-	assert(t, err == nil)
+	assert(t, err == io.EOF)
 }
 
 func TestMultilineControlParse(t *testing.T) {


### PR DESCRIPTION
This is more consistent with how the Go stdlib works, see e.g. https://golang.org/pkg/bufio/#Reader.ReadString