### PR TITLE
Refactor rfc2822 code into a separate package

### DIFF
--- a/control/changes.go
+++ b/control/changes.go
@@ -30,6 +30,7 @@ import (
 
 	"pault.ag/go/debian/dependency"
 	"pault.ag/go/debian/internal"
+	"pault.ag/go/debian/rfc2822"
 	"pault.ag/go/debian/version"
 )
 
@@ -74,7 +75,7 @@ func (c *FileListChangesFileHash) UnmarshalControl(data string) error {
 // debian/control file and other data about the source package gathered via
 // debian/changelog and debian/rules.
 type Changes struct {
-	Paragraph
+	rfc2822.Paragraph
 
 	Filename string
 
@@ -120,7 +121,7 @@ func ParseChangesFile(path string) (ret *Changes, err error) {
 // to something invalid if you're not using those functions.
 func ParseChanges(reader *bufio.Reader, path string) (*Changes, error) {
 	ret := &Changes{Filename: path}
-	return ret, Unmarshal(ret, reader)
+	return ret, rfc2822.Unmarshal(ret, reader)
 }
 
 // Return a DSC struct for the DSC listed in the .changes file. This requires

--- a/control/dsc.go
+++ b/control/dsc.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	"pault.ag/go/debian/dependency"
+	"pault.ag/go/debian/rfc2822"
 	"pault.ag/go/debian/version"
 
 	"pault.ag/go/topsort"
@@ -39,7 +40,7 @@ import (
 // When unpacking, it is checked against the files and directories in the
 // other parts of the source package.
 type DSC struct {
-	Paragraph
+	rfc2822.Paragraph
 
 	Filename string
 
@@ -138,7 +139,7 @@ func ParseDscFile(path string) (ret *DSC, err error) {
 // for use.
 func ParseDsc(reader *bufio.Reader, path string) (*DSC, error) {
 	ret := DSC{Filename: path}
-	err := Unmarshal(&ret, reader)
+	err := rfc2822.Unmarshal(&ret, reader)
 	if err != nil {
 		return nil, err
 	}

--- a/control/framework_test.go
+++ b/control/framework_test.go
@@ -1,0 +1,29 @@
+package control_test
+
+import (
+	"io"
+	"log"
+	"testing"
+)
+
+func isok(t *testing.T, err error) {
+	if err != nil && err != io.EOF {
+		log.Printf("Error! Error is not nil! - %s\n", err)
+		t.FailNow()
+	}
+}
+
+func notok(t *testing.T, err error) {
+	if err == nil {
+		log.Printf("Error! Error is nil!\n")
+		t.FailNow()
+	}
+}
+
+func assert(t *testing.T, expr bool) {
+	if !expr {
+		log.Printf("Assertion failed!")
+		t.FailNow()
+	}
+}
+

--- a/control/index.go
+++ b/control/index.go
@@ -24,8 +24,18 @@ import (
 	"bufio"
 
 	"pault.ag/go/debian/dependency"
+	"pault.ag/go/debian/rfc2822"
 	"pault.ag/go/debian/version"
 )
+
+func getOptionalDependencyField(para rfc2822.Paragraph, field string) dependency.Dependency {
+	val := para.Values[field]
+	dep, err := dependency.Parse(val)
+	if err != nil {
+		return dependency.Dependency{}
+	}
+	return *dep
+}
 
 // The BinaryIndex struct represents the exported APT Binary package index
 // file, as seen on Debian (and Debian derived) mirrors, as well as the
@@ -35,7 +45,7 @@ import (
 // to examine things like Built-Using, Depends, Tags or Binary packages
 // present on an Architecture.
 type BinaryIndex struct {
-	Paragraph
+	rfc2822.Paragraph
 
 	Package        string
 	Source         string
@@ -61,27 +71,27 @@ type BinaryIndex struct {
 
 // Parse the Depends Dependency relation on this package.
 func (index *BinaryIndex) GetDepends() dependency.Dependency {
-	return index.getOptionalDependencyField("Depends")
+	return getOptionalDependencyField(index.Paragraph, "Depends")
 }
 
 // Parse the Depends Suggests relation on this package.
 func (index *BinaryIndex) GetSuggests() dependency.Dependency {
-	return index.getOptionalDependencyField("Suggests")
+	return getOptionalDependencyField(index.Paragraph, "Suggests")
 }
 
 // Parse the Depends Breaks relation on this package.
 func (index *BinaryIndex) GetBreaks() dependency.Dependency {
-	return index.getOptionalDependencyField("Breaks")
+	return getOptionalDependencyField(index.Paragraph, "Breaks")
 }
 
 // Parse the Depends Replaces relation on this package.
 func (index *BinaryIndex) GetReplaces() dependency.Dependency {
-	return index.getOptionalDependencyField("Replaces")
+	return getOptionalDependencyField(index.Paragraph, "Replaces")
 }
 
 // Parse the Depends Pre-Depends relation on this package.
 func (index *BinaryIndex) GetPreDepends() dependency.Dependency {
-	return index.getOptionalDependencyField("Pre-Depends")
+	return getOptionalDependencyField(index.Paragraph, "Pre-Depends")
 }
 
 // The SourceIndex struct represents the exported APT Source index
@@ -92,7 +102,7 @@ func (index *BinaryIndex) GetPreDepends() dependency.Dependency {
 // Binary packages built by Source packages, who maintains a package,
 // or where to find the VCS repo for that package.
 type SourceIndex struct {
-	Paragraph
+	rfc2822.Paragraph
 
 	Package  string
 	Binaries []string `control:"Binary" delim:","`
@@ -118,20 +128,20 @@ type SourceIndex struct {
 
 // Parse the Depends Build-Depends relation on this package.
 func (index *SourceIndex) GetBuildDepends() dependency.Dependency {
-	return index.getOptionalDependencyField("Build-Depends")
+	return getOptionalDependencyField(index.Paragraph, "Build-Depends")
 }
 
 // Given a reader, parse out a list of BinaryIndex structs.
 func ParseBinaryIndex(reader *bufio.Reader) (ret []BinaryIndex, err error) {
 	ret = []BinaryIndex{}
-	err = Unmarshal(&ret, reader)
+	err = rfc2822.Unmarshal(&ret, reader)
 	return ret, err
 }
 
 // Given a reader, parse out a list of SourceIndex structs.
 func ParseSourceIndex(reader *bufio.Reader) (ret []SourceIndex, err error) {
 	ret = []SourceIndex{}
-	err = Unmarshal(&ret, reader)
+	err = rfc2822.Unmarshal(&ret, reader)
 	return ret, err
 }
 

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -29,8 +29,8 @@ import (
 	"path"
 	"strings"
 
-	"pault.ag/go/debian/control"
 	"pault.ag/go/debian/dependency"
+	"pault.ag/go/debian/rfc2822"
 	"pault.ag/go/debian/version"
 )
 
@@ -40,7 +40,7 @@ import (
 // archive, as defined in Debian Policy, section 5.3, entitiled "Binary
 // package control files -- DEBIAN/control".
 type Control struct {
-	control.Paragraph
+	rfc2822.Paragraph
 
 	Package       string `required:"true"`
 	Source        string
@@ -202,7 +202,7 @@ func loadDeb2Control(archive *Ar, deb *Deb) error {
 					return err
 				}
 				if path.Clean(member.Name) == "control" {
-					return control.Unmarshal(&deb.Control, archive)
+					return rfc2822.Unmarshal(&deb.Control, archive)
 				}
 			}
 		}

--- a/rfc2822/decode.go
+++ b/rfc2822/decode.go
@@ -18,7 +18,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE. }}} */
 
-package control
+package rfc2822
 
 import (
 	"fmt"

--- a/rfc2822/decode_test.go
+++ b/rfc2822/decode_test.go
@@ -1,10 +1,10 @@
-package control_test
+package rfc2822_test
 
 import (
 	"strings"
 	"testing"
 
-	"pault.ag/go/debian/control"
+	"pault.ag/go/debian/rfc2822"
 	"pault.ag/go/debian/dependency"
 	"pault.ag/go/debian/version"
 )
@@ -24,7 +24,7 @@ type TestStruct struct {
 
 func TestBasicUnmarshal(t *testing.T) {
 	foo := TestStruct{}
-	isok(t, control.Unmarshal(&foo, strings.NewReader(`Value: foo
+	isok(t, rfc2822.Unmarshal(&foo, strings.NewReader(`Value: foo
 Foo-Bar: baz
 `)))
 	assert(t, foo.Value == "foo")
@@ -32,7 +32,7 @@ Foo-Bar: baz
 
 func TestBasicArrayUnmarshal(t *testing.T) {
 	foo := []TestStruct{}
-	isok(t, control.Unmarshal(&foo, strings.NewReader(`Value: foo
+	isok(t, rfc2822.Unmarshal(&foo, strings.NewReader(`Value: foo
 Foo-Bar: baz
 
 Value: Bar
@@ -45,7 +45,7 @@ Value: Baz
 
 func TestTagUnmarshal(t *testing.T) {
 	foo := TestStruct{}
-	isok(t, control.Unmarshal(&foo, strings.NewReader(`Value: foo
+	isok(t, rfc2822.Unmarshal(&foo, strings.NewReader(`Value: foo
 Value-Two: baz
 `)))
 	assert(t, foo.Value == "foo")
@@ -54,20 +54,20 @@ Value-Two: baz
 
 func TestDependsUnmarshal(t *testing.T) {
 	foo := TestStruct{}
-	isok(t, control.Unmarshal(&foo, strings.NewReader(`Value: foo
+	isok(t, rfc2822.Unmarshal(&foo, strings.NewReader(`Value: foo
 Depends: foo, bar
 `)))
 	assert(t, foo.Value == "foo")
 	assert(t, foo.Depends.Relations[0].Possibilities[0].Name == "foo")
 
 	/* Actually invalid below */
-	notok(t, control.Unmarshal(&foo, strings.NewReader(`Depends: foo (>= 1.0) (<= 1.0)
+	notok(t, rfc2822.Unmarshal(&foo, strings.NewReader(`Depends: foo (>= 1.0) (<= 1.0)
 `)))
 }
 
 func TestVersionUnmarshal(t *testing.T) {
 	foo := TestStruct{}
-	isok(t, control.Unmarshal(&foo, strings.NewReader(`Value: foo
+	isok(t, rfc2822.Unmarshal(&foo, strings.NewReader(`Value: foo
 Version: 1.0-1
 `)))
 	assert(t, foo.Value == "foo")
@@ -76,14 +76,14 @@ Version: 1.0-1
 
 func TestArchUnmarshal(t *testing.T) {
 	foo := TestStruct{}
-	isok(t, control.Unmarshal(&foo, strings.NewReader(`Value: foo
+	isok(t, rfc2822.Unmarshal(&foo, strings.NewReader(`Value: foo
 Arch: amd64
 `)))
 	assert(t, foo.Value == "foo")
 	assert(t, foo.Arch.CPU == "amd64")
 
 	foo = TestStruct{}
-	isok(t, control.Unmarshal(&foo, strings.NewReader(`Value: foo
+	isok(t, rfc2822.Unmarshal(&foo, strings.NewReader(`Value: foo
 Arches: amd64 sparc any
 `)))
 	assert(t, foo.Value == "foo")
@@ -94,7 +94,7 @@ Arches: amd64 sparc any
 
 func TestNestedUnmarshal(t *testing.T) {
 	foo := TestStruct{}
-	isok(t, control.Unmarshal(&foo, strings.NewReader(`Value: foo
+	isok(t, rfc2822.Unmarshal(&foo, strings.NewReader(`Value: foo
 Fnord-Foo-Bar: Thing
 `)))
 	assert(t, foo.Value == "foo")
@@ -103,7 +103,7 @@ Fnord-Foo-Bar: Thing
 
 func TestListUnmarshal(t *testing.T) {
 	foo := TestStruct{}
-	isok(t, control.Unmarshal(&foo, strings.NewReader(`Value: foo
+	isok(t, rfc2822.Unmarshal(&foo, strings.NewReader(`Value: foo
 ValueThree: foo bar baz
 `)))
 	assert(t, foo.Value == "foo")
@@ -112,6 +112,6 @@ ValueThree: foo bar baz
 
 func TestRequiredUnmarshal(t *testing.T) {
 	foo := TestStruct{}
-	notok(t, control.Unmarshal(&foo, strings.NewReader(`Foo-Bar: baz
+	notok(t, rfc2822.Unmarshal(&foo, strings.NewReader(`Foo-Bar: baz
 `)))
 }

--- a/rfc2822/encode.go
+++ b/rfc2822/encode.go
@@ -18,7 +18,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE. }}} */
 
-package control
+package rfc2822
 
 import (
 	"fmt"
@@ -40,10 +40,10 @@ type Marshallable interface {
 
 // ConvertToParagraph {{{
 
-// Given a Struct, convert that Struct back into a control.Paragraph.
+// Given a Struct, convert that Struct back into a rfc2822.Paragraph.
 // This is not exactly useful as part of the external API, but may be
 // useful in some funny circumstances where you need to treat a Struct
-// you Unmarshaled into as a control.Paragraph again.
+// you Unmarshaled into as a rfc2822.Paragraph again.
 //
 // In most cases, the Marshal API should be sufficient. Use of this API
 // is mildly discouraged.
@@ -144,7 +144,7 @@ func marshalStructValueStruct(field reflect.Value, fieldType reflect.StructField
 	}
 
 	return "", fmt.Errorf(
-		"Type '%s' does not implement control.Marshallable",
+		"Type '%s' does not implement rfc2822.Marshallable",
 		field.Type().Name(),
 	)
 }
@@ -186,7 +186,7 @@ func marshalStructValueSlice(field reflect.Value, fieldType reflect.StructField)
 //
 // It's also worth noting that this *will* also write out elements that
 // were Unmarshaled into a Struct without a member of that name if (and only
-// if) the target Struct contains a `control.Paragraph` anonymous member.
+// if) the target Struct contains a `rfc2822.Paragraph` anonymous member.
 //
 // This is handy if the Unmarshaler was given any `X-*` keys that were not
 // present on your Struct.

--- a/rfc2822/encode_test.go
+++ b/rfc2822/encode_test.go
@@ -1,11 +1,11 @@
-package control_test
+package rfc2822_test
 
 import (
 	"bytes"
 	"strings"
 	"testing"
 
-	"pault.ag/go/debian/control"
+	"pault.ag/go/debian/rfc2822"
 	"pault.ag/go/debian/dependency"
 	"pault.ag/go/debian/version"
 )
@@ -15,28 +15,28 @@ type TestMarshalStruct struct {
 }
 
 type SomeComplexStruct struct {
-	control.Paragraph
+	rfc2822.Paragraph
 
 	Version    version.Version
 	Dependency dependency.Dependency
 }
 
 type TestParaMarshalStruct struct {
-	control.Paragraph
+	rfc2822.Paragraph
 	Foo string
 }
 
 func TestExtraMarshal(t *testing.T) {
 	el := TestParaMarshalStruct{}
 
-	isok(t, control.Unmarshal(&el, strings.NewReader(`Foo: test
+	isok(t, rfc2822.Unmarshal(&el, strings.NewReader(`Foo: test
 X-A-Test: Foo
 `)))
 
 	assert(t, el.Foo == "test")
 
 	writer := bytes.Buffer{}
-	isok(t, control.Marshal(&writer, el))
+	isok(t, rfc2822.Marshal(&writer, el))
 	assert(t, writer.String() == `Foo: test
 X-A-Test: Foo
 `)
@@ -46,14 +46,14 @@ func TestBasicMarshal(t *testing.T) {
 	testStruct := TestMarshalStruct{Foo: "Hello"}
 
 	writer := bytes.Buffer{}
-	err := control.Marshal(&writer, testStruct)
+	err := rfc2822.Marshal(&writer, testStruct)
 	isok(t, err)
 
 	assert(t, writer.String() == `Foo: Hello
 `)
 
 	writer = bytes.Buffer{}
-	err = control.Marshal(&writer, []TestMarshalStruct{
+	err = rfc2822.Marshal(&writer, []TestMarshalStruct{
 		testStruct,
 	})
 	isok(t, err)
@@ -61,7 +61,7 @@ func TestBasicMarshal(t *testing.T) {
 `)
 
 	writer = bytes.Buffer{}
-	err = control.Marshal(&writer, []TestMarshalStruct{
+	err = rfc2822.Marshal(&writer, []TestMarshalStruct{
 		testStruct,
 		testStruct,
 	})
@@ -75,14 +75,14 @@ Foo: Hello
 
 func TestExternalMarshal(t *testing.T) {
 	testStruct := SomeComplexStruct{}
-	isok(t, control.Unmarshal(&testStruct, strings.NewReader(`Version: 1.0-1
+	isok(t, rfc2822.Unmarshal(&testStruct, strings.NewReader(`Version: 1.0-1
 Dependency: foo, bar
 X-Foo: bar
 
 `)))
 	writer := bytes.Buffer{}
 
-	err := control.Marshal(&writer, testStruct)
+	err := rfc2822.Marshal(&writer, testStruct)
 	isok(t, err)
 
 	assert(t, testStruct.Dependency.Relations[0].Possibilities[0].Name == "foo")
@@ -101,7 +101,7 @@ Is
 A Test`}
 	writer := bytes.Buffer{}
 
-	err := control.Marshal(&writer, testStruct)
+	err := rfc2822.Marshal(&writer, testStruct)
 	isok(t, err)
 
 	assert(t, writer.String() == `Foo: Hello

--- a/rfc2822/framework_test.go
+++ b/rfc2822/framework_test.go
@@ -1,0 +1,29 @@
+package rfc2822_test
+
+import (
+	"io"
+	"log"
+	"testing"
+)
+
+func isok(t *testing.T, err error) {
+	if err != nil && err != io.EOF {
+		log.Printf("Error! Error is not nil! - %s\n", err)
+		t.FailNow()
+	}
+}
+
+func notok(t *testing.T, err error) {
+	if err == nil {
+		log.Printf("Error! Error is nil!\n")
+		t.FailNow()
+	}
+}
+
+func assert(t *testing.T, expr bool) {
+	if !expr {
+		log.Printf("Assertion failed!")
+		t.FailNow()
+	}
+}
+

--- a/rfc2822/parse.go
+++ b/rfc2822/parse.go
@@ -18,7 +18,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE. }}} */
 
-package control
+package rfc2822
 
 import (
 	"bufio"

--- a/rfc2822/parse_test.go
+++ b/rfc2822/parse_test.go
@@ -18,16 +18,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE. }}} */
 
-package control_test
+package rfc2822_test
 
 import (
-	"io"
-	"log"
 	"strings"
 	"testing"
 
 	"golang.org/x/crypto/openpgp"
-	"pault.ag/go/debian/control"
+	"pault.ag/go/debian/rfc2822"
 )
 
 /*
@@ -92,34 +90,13 @@ A8Ija2WnFdScMVRuMxDxK8yMdy1/BtZQKV6uzSt7ebHfPcUopBM4yARM8C90EbJD
 
 // }}}
 
-func isok(t *testing.T, err error) {
-	if err != nil && err != io.EOF {
-		log.Printf("Error! Error is not nil! - %s\n", err)
-		t.FailNow()
-	}
-}
-
-func notok(t *testing.T, err error) {
-	if err == nil {
-		log.Printf("Error! Error is nil!\n")
-		t.FailNow()
-	}
-}
-
-func assert(t *testing.T, expr bool) {
-	if !expr {
-		log.Printf("Assertion failed!")
-		t.FailNow()
-	}
-}
-
 /*
  *
  */
 
 func TestBasicParagraphReader(t *testing.T) {
 	// Reader {{{
-	reader, err := control.NewParagraphReader(strings.NewReader(`Para: one
+	reader, err := rfc2822.NewParagraphReader(strings.NewReader(`Para: one
 
 Para: two
 
@@ -134,7 +111,7 @@ Para: three
 }
 
 func TestOpenPGPParagraphReader(t *testing.T) {
-	reader, err := control.NewParagraphReader(strings.NewReader(signedParagraph), nil)
+	reader, err := rfc2822.NewParagraphReader(strings.NewReader(signedParagraph), nil)
 	isok(t, err)
 
 	blocks, err := reader.All()
@@ -146,7 +123,7 @@ func TestEmptyKeyringOpenPGPParagraphReader(t *testing.T) {
 	keyring := openpgp.EntityList{}
 
 	// Reader {{{
-	_, err := control.NewParagraphReader(strings.NewReader(`-----BEGIN PGP SIGNED MESSAGE-----
+	_, err := rfc2822.NewParagraphReader(strings.NewReader(`-----BEGIN PGP SIGNED MESSAGE-----
 Hash: SHA512
 
 Format: 1.8
@@ -205,7 +182,7 @@ A8Ija2WnFdScMVRuMxDxK8yMdy1/BtZQKV6uzSt7ebHfPcUopBM4yARM8C90EbJD
 }
 
 func TestLineWrapping(t *testing.T) {
-	reader, err := control.NewParagraphReader(strings.NewReader(signedParagraph), nil)
+	reader, err := rfc2822.NewParagraphReader(strings.NewReader(signedParagraph), nil)
 	isok(t, err)
 
 	el, err := reader.Next()


### PR DESCRIPTION
Hopefully this will help move it to `pault.ag/go/rfc2822` easier (unless you're happy to leave it in `/go/debian/rfc2822` -- obviously your choice).

I _think_ there may be a comment or two that still references `control.` which should be `rfc2822.`, but I'm not positive.

There's also the question of whether we should convert the `control:` struct tags to be `rfc2822:` as well (I'm thinking yes, but figured it was worth discussing before I did that bit).
