### PR TITLE
Support line continuations indented by tab.

### DIFF
--- a/control/parse.go
+++ b/control/parse.go
@@ -212,13 +212,14 @@ func (p *ParagraphReader) Next() (*Paragraph, error) {
 		 * Key line is a Key/Value mapping.
 		 */
 
-		if strings.HasPrefix(line, " ") {
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
 			/* This is a continuation line; so we're going to go ahead and
 			 * clean it up, and throw it into the list. We're going to remove
-			 * the space, and if it's a line that only has a dot on it, we'll
-			 * remove that too (since " .\n" is actually "\n"). We only
-			 * trim off space on the right hand, because indentation under
-			 * the single space is up to the data format. Not us. */
+			 * the first character (which we now know is whitespace), and if
+			 * it's a line that only has a dot on it, we'll remove that too
+			 * (since " .\n" is actually "\n"). We only trim off space on the
+			 * right hand, because indentation under the whitespace is up to
+			 * the data format. Not us. */
 
 			/* TrimFunc(line[1:], unicode.IsSpace) is identical to calling
 			 * TrimSpace. */

--- a/control/parse_test.go
+++ b/control/parse_test.go
@@ -133,6 +133,22 @@ Para: three
 	assert(t, len(blocks) == 3)
 }
 
+func TestWhitespacePrefixedLines(t *testing.T) {
+	// Reader {{{
+	reader, err := control.NewParagraphReader(strings.NewReader(`Key1: one
+  continuation
+Key2: two
+	tabbed continuation
+`), nil)
+	// }}}
+	isok(t, err)
+
+	blocks, err := reader.All()
+	isok(t, err)
+	assert(t, blocks[0].Values["Key1"] == "one\n continuation\n")
+	assert(t, blocks[0].Values["Key2"] == "two\ntabbed continuation\n")
+}
+
 func TestOpenPGPParagraphReader(t *testing.T) {
 	reader, err := control.NewParagraphReader(strings.NewReader(signedParagraph), nil)
 	isok(t, err)


### PR DESCRIPTION
(Thanks for the great package!)

This PR enables go-debian to support parsing DCF files that use a leading tab instead of a space for line continuations.