### PR TITLE
Allow Two-Character Newlines

### DIFF
--- a/control/parse.go
+++ b/control/parse.go
@@ -197,7 +197,7 @@ func (p *ParagraphReader) Next() (*Paragraph, error) {
 			return nil, err
 		}
 
-		if line == "\n" {
+		if line == "\n" || line == "\r\n" {
 			/* Lines are ended by a blank line; so we're able to go ahead
 			 * and return this guy as-is. All set. Done. Finished. */
 			return &paragraph, nil

--- a/control/parse_test.go
+++ b/control/parse_test.go
@@ -149,6 +149,24 @@ Key2: two
 	assert(t, blocks[0].Values["Key2"] == "two\ntabbed continuation\n")
 }
 
+func TestTrailingTwoCharacterNewlines(t *testing.T) {
+	// Reader {{{
+	reader, err := control.NewDecoder(strings.NewReader("Key1: one\r\nKey2: two\r\n\r\n"), nil)
+	// }}}
+	isok(t, err)
+
+	type TestStruct struct {
+		Key1 string
+		Key2 string
+	}
+
+	testStruct := TestStruct{}
+	err = reader.Decode(&testStruct)
+	isok(t, err)
+	assert(t, testStruct.Key1 == "one")
+	assert(t, testStruct.Key2 == "two")
+}
+
 func TestOpenPGPParagraphReader(t *testing.T) {
 	reader, err := control.NewParagraphReader(strings.NewReader(signedParagraph), nil)
 	isok(t, err)


### PR DESCRIPTION
If trailing newlines (at the end of the DCF file) use `\r\n` instead of simply `\n`, the parser was throwing errors. This PR attempts to bring support for trailing newlines that use `\r\n`.

CC: @trestletech