### PR TITLE
parsePossibility: don’t error on out on trailing comma

### DIFF
--- a/dependency/parser.go
+++ b/dependency/parser.go
@@ -174,7 +174,7 @@ func parsePossibility(input *input, relation *Relation) error {
 			continue
 		case ',', '|', 0: /* I'm out! */
 			if ret.Name == "" {
-				return errors.New("No package name in Possibility")
+				return nil // e.g. trailing comma in Build-Depends
 			}
 			relation.Possibilities = append(relation.Possibilities, *ret)
 			return nil


### PR DESCRIPTION
Noticed this on e.g. https://sources.debian.org/src/chasquid/0.04-1/debian/control/, which builds just fine on our buildds.