### PR TITLE
deb: switch to the more recent LZMA package

### DIFF
--- a/deb/tarfile.go
+++ b/deb/tarfile.go
@@ -31,7 +31,7 @@ import (
 	"compress/bzip2"
 	"compress/gzip"
 
-	"github.com/lxq/lzma"
+	"github.com/kjk/lzma"
 	"github.com/xi2/xz"
 )
 


### PR DESCRIPTION
…which is also already packaged in Debian. The repositories seem identical,
except the kjk one we’re switching to appears to be better maintained.