### PR TITLE
Rewrite imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go_import_path: pault.ag/go/debian
+go_import_path: github.com/paultag/go-debian
 go:
   - 1.9.x
   - 1.8.x

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ go-debian
 of helpful routines to help work with fun bits of Debian data.
 
 
-[![GoDoc](https://godoc.org/pault.ag/go/debian?status.svg)](https://godoc.org/pault.ag/go/debian)
+[![GoDoc](https://godoc.org/github.com/paultag/go-debian?status.svg)](https://godoc.org/github.com/paultag/go-debian)

--- a/changelog/changelog.go
+++ b/changelog/changelog.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"pault.ag/go/debian/version"
+	"github.com/paultag/go-debian/version"
 )
 
 // A ChangelogEntry is the encapsulation for each entry for a given version

--- a/changelog/changelog_test.go
+++ b/changelog/changelog_test.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"testing"
 
-	"pault.ag/go/debian/changelog"
+	"github.com/paultag/go-debian/changelog"
 )
 
 /*

--- a/control/changes.go
+++ b/control/changes.go
@@ -29,9 +29,9 @@ import (
 	"strconv"
 	"strings"
 
-	"pault.ag/go/debian/dependency"
-	"pault.ag/go/debian/internal"
-	"pault.ag/go/debian/version"
+	"github.com/paultag/go-debian/dependency"
+	"github.com/paultag/go-debian/internal"
+	"github.com/paultag/go-debian/version"
 )
 
 // {{{ .changes Files list entries

--- a/control/changes_test.go
+++ b/control/changes_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"pault.ag/go/debian/control"
+	"github.com/paultag/go-debian/control"
 )
 
 /*

--- a/control/control.go
+++ b/control/control.go
@@ -26,7 +26,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"pault.ag/go/debian/dependency"
+	"github.com/paultag/go-debian/dependency"
 )
 
 // Encapsulation for a debian/control file, which is a series of RFC2822-like

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"pault.ag/go/debian/control"
+	"github.com/paultag/go-debian/control"
 )
 
 /*

--- a/control/decode_test.go
+++ b/control/decode_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"pault.ag/go/debian/control"
-	"pault.ag/go/debian/dependency"
-	"pault.ag/go/debian/version"
+	"github.com/paultag/go-debian/control"
+	"github.com/paultag/go-debian/dependency"
+	"github.com/paultag/go-debian/version"
 )
 
 type TestStruct struct {

--- a/control/dsc.go
+++ b/control/dsc.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/paultag/go-debian/dependency"
 	"github.com/paultag/go-debian/version"
-	"github.com/paultag/go-topsort"
+	topsort "github.com/paultag/go-topsort"
 )
 
 // A DSC is the encapsulation of a Debian .dsc control file. This contains

--- a/control/dsc.go
+++ b/control/dsc.go
@@ -25,10 +25,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"pault.ag/go/debian/dependency"
-	"pault.ag/go/debian/version"
-
-	"pault.ag/go/topsort"
+	"github.com/paultag/go-debian/dependency"
+	"github.com/paultag/go-debian/version"
 )
 
 // A DSC is the encapsulation of a Debian .dsc control file. This contains

--- a/control/dsc.go
+++ b/control/dsc.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/paultag/go-debian/dependency"
 	"github.com/paultag/go-debian/version"
+	"github.com/paultag/go-topsort"
 )
 
 // A DSC is the encapsulation of a Debian .dsc control file. This contains

--- a/control/dsc_test.go
+++ b/control/dsc_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"pault.ag/go/debian/control"
+	"github.com/paultag/go-debian/control"
 )
 
 /*

--- a/control/encode_test.go
+++ b/control/encode_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"pault.ag/go/debian/control"
-	"pault.ag/go/debian/dependency"
-	"pault.ag/go/debian/version"
+	"github.com/paultag/go-debian/control"
+	"github.com/paultag/go-debian/dependency"
+	"github.com/paultag/go-debian/version"
 )
 
 type TestMarshalStruct struct {

--- a/control/filehash.go
+++ b/control/filehash.go
@@ -33,7 +33,7 @@ import (
 	"strconv"
 	"strings"
 
-	"pault.ag/go/debian/hashio"
+	"github.com/paultag/go-debian/hashio"
 )
 
 // A FileHash is an entry as found in the Files, Checksum-Sha1, and

--- a/control/filehash_test.go
+++ b/control/filehash_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"pault.ag/go/debian/control"
+	"github.com/paultag/go-debian/control"
 )
 
 func TestCrashWithoutDelim(t *testing.T) {

--- a/control/index.go
+++ b/control/index.go
@@ -24,8 +24,8 @@ import (
 	"bufio"
 	"strings"
 
-	"pault.ag/go/debian/dependency"
-	"pault.ag/go/debian/version"
+	"github.com/paultag/go-debian/dependency"
+	"github.com/paultag/go-debian/version"
 )
 
 // The BinaryIndex struct represents the exported APT Binary package index

--- a/control/index_test.go
+++ b/control/index_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"pault.ag/go/debian/control"
+	"github.com/paultag/go-debian/control"
 )
 
 func TestSourceIndexParse(t *testing.T) {

--- a/control/parse_test.go
+++ b/control/parse_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	"golang.org/x/crypto/openpgp"
-	"pault.ag/go/debian/control"
+	"github.com/paultag/go-debian/control"
 )
 
 /*

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -29,9 +29,9 @@ import (
 	"path"
 	"strings"
 
-	"pault.ag/go/debian/control"
-	"pault.ag/go/debian/dependency"
-	"pault.ag/go/debian/version"
+	"github.com/paultag/go-debian/control"
+	"github.com/paultag/go-debian/dependency"
+	"github.com/paultag/go-debian/version"
 )
 
 // Control {{{

--- a/deb/doc.go
+++ b/deb/doc.go
@@ -18,7 +18,7 @@ Here's a trivial example, which will print out the Package name for a
 		"log"
 		"os"
 
-		"pault.ag/go/debian/deb"
+		"github.com/paultag/go-debian/deb"
 	)
 
 	func main() {

--- a/dependency/arch_test.go
+++ b/dependency/arch_test.go
@@ -23,7 +23,7 @@ package dependency_test
 import (
 	"testing"
 
-	"pault.ag/go/debian/dependency"
+	"github.com/paultag/go-debian/dependency"
 )
 
 /*

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -21,7 +21,7 @@
 package dependency
 
 import (
-	"pault.ag/go/debian/version"
+	"github.com/paultag/go-debian/version"
 )
 
 //

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -23,8 +23,8 @@ package dependency_test
 import (
 	"testing"
 
-	"pault.ag/go/debian/dependency"
-	"pault.ag/go/debian/version"
+	"github.com/paultag/go-debian/dependency"
+	"github.com/paultag/go-debian/version"
 )
 
 /*

--- a/dependency/parser_test.go
+++ b/dependency/parser_test.go
@@ -25,7 +25,7 @@ import (
 	"runtime/debug"
 	"testing"
 
-	"pault.ag/go/debian/dependency"
+	"github.com/paultag/go-debian/dependency"
 )
 
 /*

--- a/dependency/string_test.go
+++ b/dependency/string_test.go
@@ -23,7 +23,7 @@ package dependency_test
 import (
 	"testing"
 
-	"pault.ag/go/debian/dependency"
+	"github.com/paultag/go-debian/dependency"
 )
 
 func TestArchString(t *testing.T) {


### PR DESCRIPTION
Currently https://pault.ag/go/debian is down which breaks the import of this package. We use dep to manage dependencies and while dep supports using a different source url, it does a name validation and the original domain name must be reachable.

golang/dep#1159

This change will remove the custom domain as a potential point of failure in the import process and allow the package to be imported directly from github.