### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/control/changes.go
+++ b/control/changes.go
@@ -124,7 +124,7 @@ func ParseChanges(reader *bufio.Reader, path string) (*Changes, error) {
 	return ret, Unmarshal(ret, reader)
 }
 
-// Return a list of FileListChangesFileHash entries from the `changes.Files`
+// AbsFiles returns a list of FileListChangesFileHash entries from the `changes.Files`
 // entry, with the exception that each `Filename` will be joined to the root
 // directory of the Changes file.
 func (changes *Changes) AbsFiles() []FileListChangesFileHash {
@@ -139,7 +139,7 @@ func (changes *Changes) AbsFiles() []FileListChangesFileHash {
 	return ret
 }
 
-// Return a DSC struct for the DSC listed in the .changes file. This requires
+// GetDSC returns a DSC struct for the DSC listed in the .changes file. This requires
 // Changes.Filename to be correctly set, and for the .dsc file to exist
 // in the correct place next to the .changes.
 //

--- a/control/control.go
+++ b/control/control.go
@@ -65,7 +65,7 @@ type SourceParagraph struct {
 	BuildConflictsIndep dependency.Dependency `control:"Build-Conflicts-Indep"`
 }
 
-// Return a list of all entities that are responsible for the package's
+// Maintainers returns a list of all entities that are responsible for the package's
 // well being. The 0th element is always the package's Maintainer,
 // with any Uploaders following.
 func (s *SourceParagraph) Maintainers() []string {

--- a/control/dsc.go
+++ b/control/dsc.go
@@ -155,7 +155,7 @@ func ParseDsc(reader *bufio.Reader, path string) (*DSC, error) {
 	return &ret, nil
 }
 
-// Check to see if this .dsc contains any arch:all binary packages along
+// HasArchAll checks to see if this .dsc contains any arch:all binary packages along
 // with any arch dependent packages.
 func (d *DSC) HasArchAll() bool {
 	for _, arch := range d.Architectures {
@@ -166,14 +166,14 @@ func (d *DSC) HasArchAll() bool {
 	return false
 }
 
-// Return a list of all entities that are responsible for the package's
+// Maintainers returns a list of all entities that are responsible for the package's
 // well being. The 0th element is always the package's Maintainer,
 // with any Uploaders following.
 func (d *DSC) Maintainers() []string {
 	return append([]string{d.Maintainer}, d.Uploaders...)
 }
 
-// Return a list of MD5FileHash entries from the `dsc.Files`
+// AbsFiles returns a list of MD5FileHash entries from the `dsc.Files`
 // entry, with the exception that each `Filename` will be joined to the root
 // directory of the DSC file.
 func (d *DSC) AbsFiles() []MD5FileHash {
@@ -253,7 +253,7 @@ func (d *DSC) Remove() error {
 	return os.Remove(d.Filename)
 }
 
-// Return the name of the Debian source. This is assumed to be the first file
+// DebianSource returns the name of the Debian source. This is assumed to be the first file
 // that contains ".debian." in its name.
 func (d *DSC) DebianSource() (string, error) {
 	for _, file := range d.Files {

--- a/control/encode.go
+++ b/control/encode.go
@@ -266,7 +266,7 @@ func NewEncoder(writer io.Writer) (*Encoder, error) {
 
 // Encode {{{
 
-// Take a Struct, Encode it into a Paragraph, and write that out to the
+// Encode takes a Struct, Encode it into a Paragraph, and write that out to the
 // io.Writer set up when the Encoder was configured.
 func (e *Encoder) Encode(incoming interface{}) error {
 	data := reflect.ValueOf(incoming)

--- a/control/parse.go
+++ b/control/parse.go
@@ -144,7 +144,7 @@ func NewParagraphReader(reader io.Reader, keyring *openpgp.EntityList) (*Paragra
 
 // Signer {{{
 
-// Return the Entity (if one exists) that signed this set of Paragraphs.
+// Signer returns the Entity (if one exists) that signed this set of Paragraphs.
 func (p *ParagraphReader) Signer() *openpgp.Entity {
 	return p.signer
 }

--- a/deb/tarfile.go
+++ b/deb/tarfile.go
@@ -64,7 +64,7 @@ var knownCompressionAlgorithms = map[string]DecompressorFunc{
 	".lzma": lzmaNewReader,
 }
 
-// DecompressorFn returns a decompressing reader for the specified reader and its
+// DecompressorFor returns a decompressing reader for the specified reader and its
 // corresponding file extension ext.
 func DecompressorFor(ext string) DecompressorFunc {
 	if fn, ok := knownCompressionAlgorithms[ext]; ok {
@@ -77,7 +77,7 @@ func DecompressorFor(ext string) DecompressorFunc {
 
 // IsTarfile {{{
 
-// Check to see if the given ArEntry is, in fact, a Tarfile. This method
+// IsTarfile checks to see if the given ArEntry is, in fact, a Tarfile. This method
 // will return `true` for `control.tar.*` and `data.tar.*` files.
 //
 // This will return `false` for the `debian-binary` file. If this method


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?