### PR TITLE
Support SHA1 and SHA256 SourceIndex checksums

### DIFF
--- a/control/index.go
+++ b/control/index.go
@@ -157,11 +157,13 @@ type SourceIndex struct {
 
 	StandardsVersion string
 	Format           string
-	Files            []string `delim:"\n"`
-	VcsBrowser       string   `control:"Vcs-Browser"`
-	VcsGit           string   `control:"Vcs-Git"`
-	VcsSvn           string   `control:"Vcs-Svn"`
-	VcsBzr           string   `control:"Vcs-Bzr"`
+	Files            []MD5FileHash    `delim:"\n" strip:"\n\r\t "`
+	VcsBrowser       string           `control:"Vcs-Browser"`
+	VcsGit           string           `control:"Vcs-Git"`
+	VcsSvn           string           `control:"Vcs-Svn"`
+	VcsBzr           string           `control:"Vcs-Bzr"`
+	ChecksumsSha1    []SHA1FileHash   `control:"Checksums-Sha1" delim:"\n" strip:"\n\r\t "`
+	ChecksumsSha256  []SHA256FileHash `control:"Checksums-Sha256" delim:"\n" strip:"\n\r\t "`
 	Homepage         string
 	Directory        string
 	Priority         string

--- a/control/index_test.go
+++ b/control/index_test.go
@@ -94,6 +94,27 @@ Section: misc
 	fbautostart := sources[1]
 	assert(t, fbautostart.Maintainer == "Paul Tagliamonte <paultag@ubuntu.com>")
 	assert(t, fbautostart.VcsGit == "git://git.debian.org/collab-maint/fbautostart.git")
+
+	assert(t, len(fbautostart.Files) == 3)
+	assert(t, fbautostart.Files[0].Algorithm == "md5")
+	assert(t, fbautostart.Files[0].Hash == "9d610c30f96623cff07bd880e5cca12f")
+	assert(t, fbautostart.Files[0].Filename == "fbautostart_2.718281828-1.dsc")
+	assert(t, fbautostart.Files[0].Size == 1899)
+	assert(t, fbautostart.Files[0].ByHash == "")
+
+	assert(t, len(fbautostart.ChecksumsSha1) == 3)
+	assert(t, fbautostart.ChecksumsSha1[1].Algorithm == "sha1")
+	assert(t, fbautostart.ChecksumsSha1[1].Hash == "bc36310c15edc9acf48f0a1daf548bcc6f861372")
+	assert(t, fbautostart.ChecksumsSha1[1].Filename == "fbautostart_2.718281828.orig.tar.gz")
+	assert(t, fbautostart.ChecksumsSha1[1].Size == 92748)
+	assert(t, fbautostart.ChecksumsSha1[1].ByHash == "")
+
+	assert(t, len(fbautostart.ChecksumsSha256) == 3)
+	assert(t, fbautostart.ChecksumsSha256[2].Algorithm == "sha256")
+	assert(t, fbautostart.ChecksumsSha256[2].Hash == "49f402ff3a72653e63542037be9f4da56e318e412d26d4154f9336fb88df3519")
+	assert(t, fbautostart.ChecksumsSha256[2].Filename == "fbautostart_2.718281828-1.debian.tar.gz")
+	assert(t, fbautostart.ChecksumsSha256[2].Size == 2396)
+	assert(t, fbautostart.ChecksumsSha256[2].ByHash == "SHA256")
 }
 
 func TestBinaryIndexParse(t *testing.T) {


### PR DESCRIPTION
This adds support for more checksum formats in Sources indices and clarifies what is what in the file information.

The SourceIndex checksums get handled in the same way as in the DSC case. They should have the same format according to https://wiki.debian.org/DebianRepository/Format#A.22Sources.22_Indices.