### PR TITLE
Case insensitive rfc822 keys parsing and setting.

### DIFF
--- a/control/changes.go
+++ b/control/changes.go
@@ -67,7 +67,7 @@ func (c *FileListChangesFileHash) UnmarshalControl(data string) error {
 
 // The Changes struct is the default encapsulation of the Debian .changes
 // package filetype.This struct contains an anonymous member of type Paragraph,
-// allowing you to use the standard .Values and .Order of the Paragraph type.
+// allowing you to use the standard .Get() and .Order of the Paragraph type.
 //
 // The .changes files are used by the Debian archive maintenance software to
 // process updates to packages. They consist of a single paragraph, possibly

--- a/control/control.go
+++ b/control/control.go
@@ -98,14 +98,14 @@ type BinaryParagraph struct {
 }
 
 func (para *Paragraph) getDependencyField(field string) (*dependency.Dependency, error) {
-	if val, ok := para.Values[field]; ok {
+	if val, ok := para.Get2(field); ok {
 		return dependency.Parse(val)
 	}
 	return nil, fmt.Errorf("Field `%s' Missing", field)
 }
 
 func (para *Paragraph) getOptionalDependencyField(field string) dependency.Dependency {
-	val := para.Values[field]
+	val := para.Get(field)
 	dep, err := dependency.Parse(val)
 	if err != nil {
 		return dependency.Dependency{}

--- a/control/decode.go
+++ b/control/decode.go
@@ -66,7 +66,7 @@ type Unmarshallable interface {
 //
 // Structs that contain Paragraph as an Anonymous member will have that
 // member populated with the parsed RFC822 block, to allow access to the
-// .Values and .Order members.
+// .Get and .Order members.
 func Unmarshal(data interface{}, reader io.Reader) error {
 	decoder, err := NewDecoder(reader, nil)
 	if err != nil {
@@ -178,7 +178,7 @@ func decodeStruct(p Paragraph, into reflect.Value) error {
 			}
 		}
 
-		if value, ok := p.Values[paragraphKey]; ok {
+		if value, ok := p.Get2(paragraphKey); ok {
 			if err := decodeStructValue(field, fieldType, value); err != nil {
 				return err
 			}

--- a/control/encode.go
+++ b/control/encode.go
@@ -104,9 +104,9 @@ func convertToParagraph(data reflect.Value) (*Paragraph, error) {
 		}
 
 		order = append(order, paragraphKey)
-		values[paragraphKey] = data
+		values[strings.ToLower(paragraphKey)] = data
 	}
-	para := foundParagraph.Update(Paragraph{Order: order, Values: values})
+	para := foundParagraph.Update(Paragraph{Order: order, values: values})
 	return &para, nil
 }
 

--- a/control/parse_test.go
+++ b/control/parse_test.go
@@ -134,29 +134,26 @@ Para: three
 }
 
 func TestParagraphSet(t *testing.T) {
-	para := control.Paragraph{
-		Order:  nil,
-		Values: map[string]string{},
-	}
+	para := control.NewParagraph()
 	// Setting a key:value updates both order and values.
 	para.Set("yankee", "doodle")
 	assert(t, len(para.Order) == 1)
 	assert(t, para.Order[0] == "yankee")
-	assert(t, para.Values["yankee"] == "doodle")
+	assert(t, para.Get("Yankee") == "doodle")
 	// Adding a second key:value updates both order and values.
 	para.Set("british", "redcoat")
 	assert(t, len(para.Order) == 2)
 	assert(t, para.Order[0] == "yankee")
-	assert(t, para.Values["yankee"] == "doodle")
+	assert(t, para.Get("yankEe") == "doodle")
 	assert(t, para.Order[1] == "british")
-	assert(t, para.Values["british"] == "redcoat")
+	assert(t, para.Get("britisH") == "redcoat")
 	// Updating a previously existing key leaves order untouched.
-	para.Set("yankee", "candle")
+	para.Set("YANKEE", "candle")
 	assert(t, len(para.Order) == 2)
 	assert(t, para.Order[0] == "yankee")
-	assert(t, para.Values["yankee"] == "candle")
+	assert(t, para.Get("yanKee") == "candle")
 	assert(t, para.Order[1] == "british")
-	assert(t, para.Values["british"] == "redcoat")
+	assert(t, para.Get("brItIsh") == "redcoat")
 }
 
 func TestWhitespacePrefixedLines(t *testing.T) {

--- a/control/parse_test.go
+++ b/control/parse_test.go
@@ -171,8 +171,8 @@ Key2: two
 
 	blocks, err := reader.All()
 	isok(t, err)
-	assert(t, blocks[0].Values["Key1"] == "one\n continuation\n")
-	assert(t, blocks[0].Values["Key2"] == "two\ntabbed continuation\n")
+	assert(t, blocks[0].Get("Key1") == "one\n continuation\n")
+	assert(t, blocks[0].Get("Key2") == "two\ntabbed continuation\n")
 }
 
 func TestCommentLines(t *testing.T) {
@@ -186,8 +186,8 @@ Key2: two
 
 	blocks, err := reader.All()
 	isok(t, err)
-	assert(t, blocks[0].Values["Key1"] == "one")
-	assert(t, blocks[0].Values["Key2"] == "two")
+	assert(t, blocks[0].Get("Key1") == "one")
+	assert(t, blocks[0].Get("Key2") == "two")
 }
 
 func TestTrailingTwoCharacterNewlines(t *testing.T) {
@@ -286,7 +286,7 @@ func TestLineWrapping(t *testing.T) {
 	el, err := reader.Next()
 	isok(t, err)
 
-	assert(t, el.Values["Changes"] == `hy (0.11.0-4) unstable; urgency=medium
+	assert(t, el.Get("changes") == `hy (0.11.0-4) unstable; urgency=medium
 
   * Fix FTBFS due to rply trying to write to HOME during sphinx-build.
   * Fix build repeatability with proper override_dh_auto_clean.


### PR DESCRIPTION
WARNING: This change breaks API of Paragraph, because indexing using [] is no longer possible.
`paragraph.Values` is replaced by `paragraph.Set(key, value)`, `paragraph.Get(key)` and `paragraph.Has(key)` (latter two are also combined to `paragraph.Get2(key)`). These functions may need inline documentation (not provided)).

Paragraph structure now consists of `.Order` which is case-sentisitve and mapping `.values` which is case insensitive. Idea is to keep upper and lower characters for serializing same as in some `.Set(...)` call for given key, because case rules are ad-hoc and we would have to keep (pluggable) dictionary of cannonical spelling of keys. (Typically hash names are spellt in different ways.) Current implementation uses spelling of first `.Set(...)` call. Spelling change of key is now not supported, although one can directly edit `.Order`. Maybe some API for correcting spelling should be provided.

This change is done to support #57