### PR TITLE
Interface for relaxed checking of missing fields.

### DIFF
--- a/control/parse_test.go
+++ b/control/parse_test.go
@@ -192,7 +192,7 @@ Key2: two
 
 func TestTrailingTwoCharacterNewlines(t *testing.T) {
 	// Reader {{{
-	reader, err := control.NewDecoder(strings.NewReader("Key1: one\r\nKey2: two\r\n\r\n"), nil)
+	reader, err := control.NewDecoder(strings.NewReader("Key1: one\r\nKey2: two\r\n\r\n"), nil, nil)
 	// }}}
 	isok(t, err)
 


### PR DESCRIPTION
Alternative solution for #110, breaks some API (e.g. `control.NewDecoder`), adds two new functions `deb.LoadCtx` and `control.UnmarshalCtx`. This is proposal, it needs to be documented and it may be not complete (e.g. control.changes does not have Parse...Ctx functions as there are not `required` fields now).