### PR TITLE
Add support for zstd-compressed packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module pault.ag/go/debian
 go 1.15
 
 require (
+	github.com/DataDog/zstd v1.4.8
 	github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
+github.com/DataDog/zstd v1.4.8 h1:Rpmta4xZ/MgZnriKNd24iZMhGpP5dvUcs/uqfBapKZY=
+github.com/DataDog/zstd v1.4.8/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d h1:RnWZeH8N8KXfbwMTex/KKMYMj0FJRCF6tQubUuQ02GM=
 github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d/go.mod h1:phT/jsRPBAEqjAibu1BurrabCBNTYiVI+zbmyCZJY6Q=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
-golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
-golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
Debian has not yet added zstd support for .deb packages ( https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=892664 ), but Ubuntu already started rolling out zstd-compressed packages. See announcement here: https://balintreczey.hu/blog/hello-zstd-compressed-debs-in-ubuntu/

I tested this change with an example package: http://us.archive.ubuntu.com/ubuntu/pool/universe/t/thrift/libthrift-dev_0.13.0-6ubuntu1_amd64.deb

As you can see, this change requires using ReadCloser instead of Reader, otherwise this implementation will leak memory (allocated through cgo).
There is another implemenation of zstd (github.com/klauspost/compress/zstd ), which also requires closing, otherwise goroutines  would leak.

Since the `lzma` and the `gzip` readers were in fact ReadClosers, I went ahead and adapted the code so all resources could be freed.

The API now requires a Close to avoid leaks - this can be a breaking change for users (especially in long-running programs) - not quite sure how to handle that gracefully