### PR TITLE
fix parsing dependencies without space between name and version

### DIFF
--- a/dependency/parser.go
+++ b/dependency/parser.go
@@ -166,7 +166,7 @@ func parsePossibility(input *input, relation *Relation) error {
 				return err
 			}
 			continue
-		case ' ':
+		case ' ', '(':
 			err := parsePossibilityControllers(input, ret)
 			if err != nil {
 				return err

--- a/dependency/parser_test.go
+++ b/dependency/parser_test.go
@@ -116,6 +116,18 @@ func TestVersioning(t *testing.T) {
 	assert(t, version.Number == "1.0")
 }
 
+func TestVersioningSkippedSpace(t *testing.T) {
+	dep, err := dependency.Parse("foo(>= 1.0)")
+	isok(t, err)
+	assert(t, len(dep.Relations) == 1)
+
+	possi := dep.Relations[0].Possibilities[0]
+	version := possi.Version
+
+	assert(t, version.Operator == ">=")
+	assert(t, version.Number == "1.0")
+}
+
 func TestSingleArch(t *testing.T) {
 	dep, err := dependency.Parse("foo [arch]")
 	isok(t, err)


### PR DESCRIPTION
This prevent errors during parsing some packages found in internet. For example I have an error with this file: https://code-industry.net/public/master-pdf-editor-5.9.50-1-qt5.x86_64.deb