### PR TITLE
deb: fix ArEntry.FileMode

### DIFF
--- a/deb/ar.go
+++ b/deb/ar.go
@@ -141,7 +141,7 @@ func parseArEntry(line []byte) (*ArEntry, error) {
 
 	entry := ArEntry{
 		Name:     strings.TrimSuffix(strings.TrimSpace(string(line[0:16])), "/"),
-		FileMode: strings.TrimSpace(string(line[48:58])),
+		FileMode: strings.TrimSpace(string(line[40:48])),
 	}
 
 	for target, value := range map[*int64][]byte{

--- a/deb/ar_test.go
+++ b/deb/ar_test.go
@@ -56,6 +56,7 @@ func TestAr(t *testing.T) {
 	assert(t, firstEntry.Timestamp == 1361157466)
 	assert(t, firstEntry.OwnerID == 501)
 	assert(t, firstEntry.GroupID == 20)
+	assert(t, firstEntry.FileMode == "100644")
 
 	firstContent, err := ioutil.ReadAll(firstEntry.Data)
 	isok(t, err)


### PR DESCRIPTION
Hi,

currently the `FileMode` of ArEntry contains the size (and not the filemode).

This PR fixes this (with an added test).