### PR TITLE
Strip Whitespaces from Binary Package Names in Source Index Parsing

### DIFF
--- a/control/index.go
+++ b/control/index.go
@@ -152,7 +152,7 @@ type SourceIndex struct {
 	Paragraph
 
 	Package  string
-	Binaries []string `control:"Binary" delim:","`
+	Binaries []string `control:"Binary" delim:"," strip:" "`
 
 	Version    version.Version
 	Maintainer string


### PR DESCRIPTION
**Issue**:
When parsing source index files, binary package names could be incorrect due to the presence of whitespaces.

**Fix**:
Updated the source index struct definition to strip whitespaces from binary package names.