### PR TITLE
Rewrite the Dependency Architecture code

### DIFF
--- a/changelog/doc.go
+++ b/changelog/doc.go
@@ -1,6 +1,4 @@
 /*
-
 Parse the Debian changelog format.
-
 */
 package changelog // import "pault.ag/go/debian/changelog"

--- a/control/doc.go
+++ b/control/doc.go
@@ -1,6 +1,4 @@
 /*
-
 Parse the Debian control file format.
-
 */
 package control // import "pault.ag/go/debian/control"

--- a/control/dsc.go
+++ b/control/dsc.go
@@ -159,7 +159,7 @@ func ParseDsc(reader *bufio.Reader, path string) (*DSC, error) {
 // with any arch dependent packages.
 func (d *DSC) HasArchAll() bool {
 	for _, arch := range d.Architectures {
-		if arch.CPU == "all" && arch.OS == "all" && arch.ABI == "all" {
+		if arch.CPU == "all" && arch.OS == "all" && arch.ABI == "all" && arch.Libc == "all" {
 			return true
 		}
 	}

--- a/control/filehash.go
+++ b/control/filehash.go
@@ -84,14 +84,15 @@ func (v *verifier) Close() error {
 // written to it and fails Close() upon hash mismatch.
 //
 // Example:
-//     verifier := fh.Verifier()
-//     r = io.TeeReader(r, verifier)
-//     if _, err := io.Copy(f, r); err != nil {
-//         return err
-//     }
-//     if err := verifier.Close(); err != nil {
-//         return err
-//     }
+//
+//	verifier := fh.Verifier()
+//	r = io.TeeReader(r, verifier)
+//	if _, err := io.Copy(f, r); err != nil {
+//	    return err
+//	}
+//	if err := verifier.Close(); err != nil {
+//	    return err
+//	}
 func (c *FileHash) Verifier() (io.WriteCloser, error) {
 	var h hash.Hash
 	switch c.Algorithm {

--- a/control/index.go
+++ b/control/index.go
@@ -41,7 +41,7 @@ type BinaryIndex struct {
 	Package        string
 	Source         string
 	Version        version.Version
-	InstalledSize  int     `control:"Installed-Size"`
+	InstalledSize  int `control:"Installed-Size"`
 	Maintainer     string
 	Architecture   dependency.Arch
 	MultiArch      string `control:"Multi-Arch"`

--- a/control/index_test.go
+++ b/control/index_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	"pault.ag/go/debian/control"
-    "pault.ag/go/debian/dependency"
+	"pault.ag/go/debian/dependency"
 )
 
 func TestSourceIndexParse(t *testing.T) {
@@ -179,20 +179,20 @@ SHA256: fa53e4f50349c5c9b564b8dc1da86c503b0baf56ab95a4ef6e204b6f77bfe70c
 	isok(t, err)
 	assert(t, len(sources) == 3)
 
-    assert(t, sources[2].Package == "androidsdk-ddms")
+	assert(t, sources[2].Package == "androidsdk-ddms")
 	assert(t, sources[2].Source == "androidsdk-tools")
-    assert(t, sources[2].Version.String() == "22.2+git20130830~92d25d6-1")
-    assert(t, sources[2].InstalledSize == 211)
-    assert(t, sources[2].Maintainer == "Debian Java Maintainers <pkg-java-maintainers@lists.alioth.debian.org>")
-    assert(t, sources[2].Architecture == dependency.All)
-    assert(t, sources[2].Description == "Graphical debugging tool for Android")
-    assert(t, sources[2].Homepage == "http://developer.android.com/tools/help/index.html")
-    assert(t, sources[2].Section == "java")
-    assert(t, sources[2].Priority == "extra")
+	assert(t, sources[2].Version.String() == "22.2+git20130830~92d25d6-1")
+	assert(t, sources[2].InstalledSize == 211)
+	assert(t, sources[2].Maintainer == "Debian Java Maintainers <pkg-java-maintainers@lists.alioth.debian.org>")
+	assert(t, sources[2].Architecture == dependency.All)
+	assert(t, sources[2].Description == "Graphical debugging tool for Android")
+	assert(t, sources[2].Homepage == "http://developer.android.com/tools/help/index.html")
+	assert(t, sources[2].Section == "java")
+	assert(t, sources[2].Priority == "extra")
 	assert(t, sources[2].Filename == "pool/main/a/androidsdk-tools/androidsdk-ddms_22.2+git20130830~92d25d6-1_all.deb")
-    assert(t, sources[2].Size == 132048)
-    assert(t, sources[2].MD5sum == "fde05f3552457e91a415c99ab2a2a514")
-    assert(t, sources[2].SHA256 == "fa53e4f50349c5c9b564b8dc1da86c503b0baf56ab95a4ef6e204b6f77bfe70c")
+	assert(t, sources[2].Size == 132048)
+	assert(t, sources[2].MD5sum == "fde05f3552457e91a415c99ab2a2a514")
+	assert(t, sources[2].SHA256 == "fa53e4f50349c5c9b564b8dc1da86c503b0baf56ab95a4ef6e204b6f77bfe70c")
 }
 
 func TestBinaryIndexDependsParse(t *testing.T) {
@@ -255,12 +255,12 @@ Description-md5: d05e72aec9e53ee776fc0735e135889b
 	assert(t, len(sources) == 1)
 
 	pkgconflicts := sources[0].GetConflicts()
-    conflicts := pkgconflicts.GetAllPossibilities()
-    assert(t, len(conflicts) == 1)
+	conflicts := pkgconflicts.GetAllPossibilities()
+	assert(t, len(conflicts) == 1)
 
 	assert(t, conflicts[0].Name == "somepackage")
-    assert(t, conflicts[0].Version.Number == "5.0")
-    assert(t, conflicts[0].Version.Operator == ">=")
+	assert(t, conflicts[0].Version.Number == "5.0")
+	assert(t, conflicts[0].Version.Operator == ">=")
 }
 
 // vim: foldmethod=marker

--- a/deb/deb.go
+++ b/deb/deb.go
@@ -47,8 +47,8 @@ type Control struct {
 	Version       version.Version `required:"true"`
 	Architecture  dependency.Arch `required:"true"`
 	Maintainer    string
-	InstalledSize int             `control:"Installed-Size"`
-	MultiArch     string          `control:"Multi-Arch"`
+	InstalledSize int    `control:"Installed-Size"`
+	MultiArch     string `control:"Multi-Arch"`
 	Depends       dependency.Dependency
 	Recommends    dependency.Dependency
 	Suggests      dependency.Dependency

--- a/deb/doc.go
+++ b/deb/doc.go
@@ -1,5 +1,4 @@
 /*
-
 This module provides an API to access and programmatically process
 Debian `.deb` archives on disk.
 
@@ -35,6 +34,5 @@ Here's a trivial example, which will print out the Package name for a
 		}
 		log.Printf("Package: %s\n", debFile.Control.Package)
 	}
-
 */
 package deb // import "pault.ag/go/debian/deb"

--- a/dependency/arch_test.go
+++ b/dependency/arch_test.go
@@ -34,8 +34,15 @@ func TestArchBasics(t *testing.T) {
 	arch, err := dependency.ParseArch("amd64")
 	isok(t, err)
 	assert(t, arch.CPU == "amd64")
-	assert(t, arch.ABI == "gnu")
+	assert(t, arch.ABI == "base")
+	assert(t, arch.Libc == "gnu")
 	assert(t, arch.OS == "linux")
+}
+
+func TestArchCompareX32(t *testing.T) {
+	archX32, _ := dependency.ParseArch("x32")
+	archAnyAmd64, _ := dependency.ParseArch("any-amd64")
+	assert(t, archX32.Is(archAnyAmd64))
 }
 
 /*
@@ -45,11 +52,10 @@ func TestArchCompareBasics(t *testing.T) {
 	isok(t, err)
 
 	equivs := []string{
-		"gnu-linux-amd64",
-		"linux-amd64",
+		"base-gnu-linux-amd64",
 		"linux-any",
 		"any",
-		"gnu-linux-any",
+		"base-gnu-linux-any",
 	}
 
 	for _, el := range equivs {
@@ -60,12 +66,12 @@ func TestArchCompareBasics(t *testing.T) {
 	}
 
 	unequivs := []string{
-		"gnu-linux-all",
+		"base-gnu-linux-all",
 		"all",
 
-		"gnuu-linux-amd64",
-		"gnu-linuxx-amd64",
-		"gnu-linux-amd644",
+		"base-gnuu-linux-amd64",
+		"base-gnu-linuxx-amd64",
+		"base-gnu-linux-amd644",
 	}
 
 	for _, el := range unequivs {

--- a/dependency/arch_tupletable.go
+++ b/dependency/arch_tupletable.go
@@ -1,0 +1,72 @@
+/* {{{ Copyright (c) Paul R. Tagliamonte <paultag@debian.org>, 2025
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE. }}} */
+
+package dependency
+
+var TUPLETABLE = string(`
+eabi-uclibc-linux-arm		uclibc-linux-armel
+base-uclibc-linux-<cpu>		uclibc-linux-<cpu>
+eabihf-musl-linux-arm		musl-linux-armhf
+base-musl-linux-<cpu>		musl-linux-<cpu>
+eabihf-gnu-linux-arm		armhf
+eabi-gnu-linux-arm		armel
+abin32-gnu-linux-mips64r6el	mipsn32r6el
+abin32-gnu-linux-mips64r6	mipsn32r6
+abin32-gnu-linux-mips64el	mipsn32el
+abin32-gnu-linux-mips64		mipsn32
+abi64-gnu-linux-mips64r6el	mips64r6el
+abi64-gnu-linux-mips64r6	mips64r6
+abi64-gnu-linux-mips64el	mips64el
+abi64-gnu-linux-mips64		mips64
+spe-gnu-linux-powerpc		powerpcspe
+x32-gnu-linux-amd64		x32
+base-gnu-linux-<cpu>		<cpu>
+base-gnu-kfreebsd-amd64		kfreebsd-amd64
+base-gnu-kfreebsd-i386		kfreebsd-i386
+base-gnu-kopensolaris-amd64	kopensolaris-amd64
+base-gnu-kopensolaris-i386	kopensolaris-i386
+base-gnu-hurd-amd64		hurd-amd64
+base-gnu-hurd-i386		hurd-i386
+base-bsd-dragonflybsd-amd64	dragonflybsd-amd64
+base-bsd-freebsd-amd64		freebsd-amd64
+base-bsd-freebsd-arm		freebsd-arm
+base-bsd-freebsd-arm64		freebsd-arm64
+base-bsd-freebsd-i386		freebsd-i386
+base-bsd-freebsd-powerpc	freebsd-powerpc
+base-bsd-freebsd-ppc64		freebsd-ppc64
+base-bsd-freebsd-riscv		freebsd-riscv
+base-bsd-openbsd-<cpu>		openbsd-<cpu>
+base-bsd-netbsd-<cpu>		netbsd-<cpu>
+base-bsd-darwin-amd64		darwin-amd64
+base-bsd-darwin-arm		darwin-arm
+base-bsd-darwin-arm64		darwin-arm64
+base-bsd-darwin-i386		darwin-i386
+base-bsd-darwin-powerpc		darwin-powerpc
+base-bsd-darwin-ppc64		darwin-ppc64
+base-sysv-aix-powerpc		aix-powerpc
+base-sysv-aix-ppc64		aix-ppc64
+base-sysv-solaris-amd64		solaris-amd64
+base-sysv-solaris-i386		solaris-i386
+base-sysv-solaris-sparc		solaris-sparc
+base-sysv-solaris-sparc64	solaris-sparc64
+base-tos-mint-m68k		mint-m68k
+`)
+
+// vim: foldmethod=marker

--- a/dependency/consts.go
+++ b/dependency/consts.go
@@ -21,8 +21,8 @@
 package dependency // import "pault.ag/go/debian/dependency"
 
 var (
-	Any = Arch{ABI: "any", OS: "any", CPU: "any"}
-	All = Arch{ABI: "all", OS: "all", CPU: "all"}
+	Any = Arch{ABI: "any", Libc: "any", OS: "any", CPU: "any"}
+	All = Arch{ABI: "all", Libc: "all", OS: "all", CPU: "all"}
 )
 
 // vim: foldmethod=marker

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -24,7 +24,6 @@ import (
 	"pault.ag/go/debian/version"
 )
 
-//
 func (dep *Dependency) GetPossibilities(arch Arch) []Possibility {
 	possies := []Possibility{}
 
@@ -44,7 +43,6 @@ func (dep *Dependency) GetPossibilities(arch Arch) []Possibility {
 	return possies
 }
 
-//
 func (dep *Dependency) GetAllPossibilities() []Possibility {
 	possies := []Possibility{}
 
@@ -60,7 +58,6 @@ func (dep *Dependency) GetAllPossibilities() []Possibility {
 	return possies
 }
 
-//
 func (dep *Dependency) GetSubstvars() []Possibility {
 	possies := []Possibility{}
 

--- a/dependency/doc.go
+++ b/dependency/doc.go
@@ -1,15 +1,13 @@
 /*
-
 The Dependency module provides an interface to parse and inspect Debian
 Dependency relationships.
 
-
- Dependency                |               foo, bar (>= 1.0) [amd64] | baz
-   -> Relations            | -> Relation        bar (>= 1.0) [amd64] | baz
-        -> Possibilities   | -> Possibility     bar (>= 1.0) [amd64]
-           | Name          | -> Name            bar
-           | Version       | -> Version             (>= 1.0)
-           | Architectures | -> Arch                          amd64
-           | Stages        |
+	Dependency                |               foo, bar (>= 1.0) [amd64] | baz
+	  -> Relations            | -> Relation        bar (>= 1.0) [amd64] | baz
+	       -> Possibilities   | -> Possibility     bar (>= 1.0) [amd64]
+	          | Name          | -> Name            bar
+	          | Version       | -> Version             (>= 1.0)
+	          | Architectures | -> Arch                          amd64
+	          | Stages        |
 */
 package dependency // import "pault.ag/go/debian/dependency"

--- a/dependency/models.go
+++ b/dependency/models.go
@@ -34,10 +34,9 @@ type ArchSet struct {
 // greater than version 1.0, or less than 2.0. The values that are valid
 // in the Operator field are defined by section 7.1 of Debian policy.
 //
-//   The relations allowed are <<, <=, =, >= and >> for strictly earlier,
-//   earlier or equal, exactly equal, later or equal and strictly later,
-//   respectively.
-//
+//	The relations allowed are <<, <=, =, >= and >> for strictly earlier,
+//	earlier or equal, exactly equal, later or equal and strictly later,
+//	respectively.
 type VersionRelation struct {
 	Number   string
 	Operator string
@@ -55,12 +54,11 @@ type StageSet struct {
 // Possibility models a concrete Possibility that may be satisfied in order
 // to satisfy the Dependency Relation. Given the Dependency line:
 //
-//   Depends: foo, bar | baz
+//	Depends: foo, bar | baz
 //
 // All of foo, bar and baz are Possibilities. Possibilities may come with
 // further restrictions, such as restrictions on Version, Architecture, or
 // Build Stage.
-//
 type Possibility struct {
 	Name          string
 	Arch          *Arch
@@ -75,7 +73,7 @@ type Possibility struct {
 // A Relation is a set of Possibilities that must be satisfied. Given the
 // Dependency line:
 //
-//   Depends: foo, bar | baz
+//	Depends: foo, bar | baz
 //
 // There are two Relations, one composed of foo, and another composed of
 // bar and baz.

--- a/dependency/string.go
+++ b/dependency/string.go
@@ -29,18 +29,7 @@ func (a Arch) MarshalControl() (string, error) {
 }
 
 func (a Arch) String() string {
-	/* ABI-OS-CPU -- gnu-linux-amd64 */
-	els := []string{}
-	if a.ABI != "any" && a.ABI != "all" && a.ABI != "gnu" && a.ABI != "" {
-		els = append(els, a.ABI)
-	}
-
-	if a.OS != "any" && a.OS != "all" && a.OS != "linux" {
-		els = append(els, a.OS)
-	}
-
-	els = append(els, a.CPU)
-	return strings.Join(els, "-")
+	return archToStringWithTupletable(a)
 }
 
 func (set ArchSet) String() string {

--- a/dependency/string_test.go
+++ b/dependency/string_test.go
@@ -28,15 +28,16 @@ import (
 
 func TestArchString(t *testing.T) {
 	equivs := map[string]string{
-		"all":              "all",
-		"any":              "all",
-		"amd64":            "amd64",
-		"gnu-linux-amd64":  "amd64",
-		"bsd-windows-i386": "bsd-windows-i386",
+		"all":                  "all",
+		"any":                  "all",
+		"amd64":                "amd64",
+		"base-gnu-linux-amd64": "amd64",
+		"foo-bsd-windows-i386": "foo-bsd-windows-i386",
 	}
 
 	for _, el := range equivs {
 		arch, err := dependency.ParseArch(el)
+
 		isok(t, err)
 		assert(t, arch.String() == equivs[el])
 	}


### PR DESCRIPTION
My old code was very annoying -- it was worse than annoying, it was *wrong*. It totally didn't deal with the libc in the tuple -- and it didn't use the correct method to match the tuples - the dpkg tupletable.

I vendored a copy of the Debian tupletable since I don't want to have it require a Debian host, but I kept the same format so it could be copy-pasted when it changes.

This is also annoying because any existing code using Arch {} directly is likely to break -- however, the code was wrong anyway, so, uh, apologies in advance.